### PR TITLE
Handle ember-auto-import chunks

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,7 +7,10 @@ export function normaliseFingerprint(obj) {
   const normalisedObject = {};
 
   Object.keys(obj).forEach((key) => {
-    const match = key.match(/dist\/assets\/([\w-]+)-\w{32}(.\w+)/);
+    const chunkRegex = /dist\/assets\/(chunk\.\d+)\.\w+(.\w+)/;
+    const assetRegex = /dist\/assets\/([\w-]+)-\w{32}(.\w+)/;
+
+    const match = key.match(assetRegex) || key.match(chunkRegex);
 
     if (match) {
       const [, fileName, extension] = match;

--- a/test/normaliseFingerprint.js
+++ b/test/normaliseFingerprint.js
@@ -7,6 +7,7 @@ describe('Normalise Fingerprint', function () {
     const assets = {
       'dist/assets/auto-import-fastboot-12a5d6f444be918dea6cd3914e6c0fc7.js': { raw: 221142, gzip: 76707, brotli: null },
       'dist/assets/chunk.c63c634560451d1b7290.js': { raw: 221142, gzip: 76707, brotli: null },
+      'dist/assets/chunk.123.c63c634560451d1b7290.js': { raw: 221142, gzip: 76707, brotli: null },
       'dist/assets/ember-website-fastboot-1d9d1bfbc74315a1a7f3621398cec1ab.js': { raw: 956, gzip: 414, brotli: null },
       'dist/assets/ember-website-fc52cd4affc83e3b7f52fe490e20b0b8.js': { raw: 389351, gzip: 71886, brotli: null },
       'dist/assets/vendor-169741f10d77b36e0ade129f9972d7a0.js': { raw: 2717593, gzip: 796082, brotli: null },
@@ -18,6 +19,7 @@ describe('Normalise Fingerprint', function () {
 
     expect(normalisedAssets).to.deep.equal({
       'auto-import-fastboot.js': { raw: 221142, gzip: 76707, brotli: null },
+      'chunk.123.js': { raw: 221142, gzip: 76707, brotli: null },
       'ember-website-fastboot.js': { raw: 956, gzip: 414, brotli: null },
       'ember-website.js': { raw: 389351, gzip: 71886, brotli: null },
       'vendor.js': { raw: 2717593, gzip: 796082, brotli: null },


### PR DESCRIPTION
Currently, any chunk generated by ember-auto-import is ignored. I just noticed this when doing a major refactoring, swapping out an underlying dependency, and not really seeing any asset size changes from this action :sweat_smile: 

This PR now also handles the `chunk.xxx.yyyyyyy.js` type output that ember-auto-import/webpack generates.
Of course, it is not necessarily super easy to know what exactly a certain chunk is, but imho it is still better to at least see that they exist/their size changed than to hide them completely.