### PR TITLE
feat/support-showing-total-diff-size-between-base-and-pr-branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
 
-### Displaying total asset sizes
+### Displaying total asset sizes differences
 
 If you'd like the PR comment to display the diff between the total asset sizes (JS & CSS) for the PR's build against the base branch, you can use the `show-total-size-diff` option:
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ jobs:
 If you'd like the PR comment to display the diff between the total asset sizes (JS & CSS) for the PR's build against the base branch, you can use the `show-total-size-diff` option:
 
 ```yaml
-- uses: simplabs/ember-asset-size-action@v1
+- uses: simplabs/ember-asset-size-action@v2
   with:
     repo-token: "${{ secrets.GITHUB_TOKEN }}"
     show-total-size-diff: "yes"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
 
+### Displaying total asset sizes
+
+If you'd like the PR comment to display total asset sizes for the PR's build, not just the diff compared to the base branch, you can use the `show-totals` option:
+
+```yaml
+- uses: simplabs/ember-asset-size-action@v1
+  with:
+    repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    show-totals: "yes"
+```
+
 ## License
 
 Ember Simple Auth is developed by and &copy; [simplabs GmbH](http://simplabs.com) and contributors. It is released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ jobs:
 
 ### Displaying total asset sizes
 
-If you'd like the PR comment to display total asset sizes for the PR's build, not just the diff compared to the base branch, you can use the `show-totals` option:
+If you'd like the PR comment to display the diff between the total asset sizes (JS & CSS) for the PR's build against the base branch, you can use the `show-total-size-diff` option:
 
 ```yaml
 - uses: simplabs/ember-asset-size-action@v1
   with:
     repo-token: "${{ secrets.GITHUB_TOKEN }}"
-    show-totals: "yes"
+    show-total-size-diff: "yes"
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,8 @@ branding:
 inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
-  show-totals:
-    description: 'Display a table of bundle size total sizes'
+  show-total-size-diff:
+    description: 'Display a table of the total differences in size for JS & CSS'
     required: false
     default: 'no'
   update-comments:

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ branding:
 inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
+  show-totals:
+    description: 'Display a table of bundle size total sizes'
+    required: false
+    default: 'no'
   update-comments:
     description: 'Update existing asset size comment instead of creating a new one each time'
     required: false

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -133,6 +133,23 @@ export function sumAssetSizes(assetSizeReport) {
   );
 }
 
+// Takes the output of sumAssetSizes for two different branches and returns an
+// object containing the change in resource sizes between the pr branch vs the
+// base branch. Only supports JS & CSS at this stage.
+export function diffTotals(baseBranchTotals, prBranchTotals) {
+  const diff = {
+    js: {},
+    css: {},
+  };
+
+  Object.keys(prBranchTotals).forEach((fileType) => {
+    diff[fileType].raw = prBranchTotals[fileType].raw - baseBranchTotals[fileType].raw;
+    diff[fileType].gzip = prBranchTotals[fileType].gzip - baseBranchTotals[fileType].gzip;
+  });
+  
+  return diff;
+}
+
 function reportTable(data) {
   let table = `File | raw | gzip
 --- | --- | ---
@@ -185,7 +202,7 @@ export function buildOutputText(output, totals) {
       { file: 'css', ...totals.css },
     ];
 
-    outputText += `Total Sizes 📊:\n\n${reportTable(totalsRows)}`;
+    outputText += `Total assets size diff📊:\n\n${reportTable(totalsRows)}`;
   }
 
   return outputText.trim();

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -112,6 +112,27 @@ export async function getAssetSizes() {
   return prAssets;
 }
 
+export function sumAssetSizes(assetSizeReport) {
+  return Object.entries(assetSizeReport).reduce(
+    (acc, [filename, fileMeta]) => {
+      let fileType;
+      if (filename.endsWith('.js')) {
+        fileType = 'js';
+      } else if (filename.endsWith('.css')) {
+        fileType = 'css';
+      } else {
+        return acc;
+      }
+
+      acc[fileType].raw += fileMeta.raw;
+      acc[fileType].gzip += fileMeta.gzip;
+
+      return acc;
+    },
+    { js: { raw: 0, gzip: 0 }, css: { raw: 0, gzip: 0 } },
+  );
+}
+
 function reportTable(data) {
   let table = `File | raw | gzip
 --- | --- | ---

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -144,7 +144,7 @@ function reportTable(data) {
   return table;
 }
 
-export function buildOutputText(output) {
+export function buildOutputText(output, totals) {
   const files = Object.keys(output).map((key) => ({
     file: key,
     raw: output[key].raw,
@@ -177,6 +177,15 @@ export function buildOutputText(output) {
 
   if (same.length) {
     outputText += `Files that stayed the same size 🤷‍:\n\n${reportTable(same)}\n\n`;
+  }
+
+  if (totals) {
+    const totalsRows = [
+      { file: 'js', ...totals.js },
+      { file: 'css', ...totals.css },
+    ];
+
+    outputText += `Total Sizes 📊:\n\n${reportTable(totalsRows)}`;
   }
 
   return outputText.trim();

--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ async function run() {
     octokit = getOctokit(myToken);
     const pullRequest = await getPullRequest(context, octokit);
 
-    const showTotals = getInput('show-totals', { required: false }) === 'yes';
+    const showTotalSizeDiff = getInput('show-total-size-diff', { required: false }) === 'yes';
     const prAssets = await getAssetSizes();
 
     await exec(`git checkout ${pullRequest.base.sha}`);
@@ -32,7 +32,7 @@ async function run() {
     const uniqueCommentIdentifier = '_Created by [ember-asset-size-action](https://github.com/simplabs/ember-asset-size-action/)_';
     
     let totalSizeDiff = null;
-    if (showTotals) {
+    if (showTotalSizeDiff) {
       const masterTotals = sumAssetSizes(masterAssets);
       const prTotals = sumAssetSizes(prAssets);
       totalSizeDiff = diffTotals(masterTotals, prTotals);

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ import {
   buildOutputText,
   getPullRequest,
   getAssetSizes,
+  sumAssetSizes,
 } from './lib/helpers';
 
 let octokit;
@@ -18,7 +19,9 @@ async function run() {
     octokit = getOctokit(myToken);
     const pullRequest = await getPullRequest(context, octokit);
 
+    const showTotals = getInput('show-totals', { required: false }) === 'yes';
     const prAssets = await getAssetSizes();
+    const prTotals = showTotals ? sumAssetSizes(prAssets) : undefined;
 
     await exec(`git checkout ${pullRequest.base.sha}`);
 
@@ -27,7 +30,7 @@ async function run() {
     const fileDiffs = diffSizes(normaliseFingerprint(masterAssets), normaliseFingerprint(prAssets));
 
     const uniqueCommentIdentifier = '_Created by [ember-asset-size-action](https://github.com/simplabs/ember-asset-size-action/)_';
-    const body = `${buildOutputText(fileDiffs)}\n\n${uniqueCommentIdentifier}`;
+    const body = `${buildOutputText(fileDiffs, prTotals)}\n\n${uniqueCommentIdentifier}`;
 
     const updateExistingComment = getInput('update-comments', { required: false });
     let existingComment = false;

--- a/test/buildOutputText.js
+++ b/test/buildOutputText.js
@@ -76,7 +76,7 @@ ember-website.css| 0 B| 0 B
 vendor.css| 0 B| 0 B
 
 
-Total Sizes 📊:
+Total assets size diff📊:
 
 File | raw | gzip
 --- | --- | ---

--- a/test/buildOutputText.js
+++ b/test/buildOutputText.js
@@ -36,4 +36,51 @@ ember-website-fastboot.js| 0 B| 0 B
 ember-website.css| 0 B| 0 B
 vendor.css| 0 B| 0 B`);
   });
+
+  it('should include total asset sizes when provided', function () {
+    const diff = {
+      'auto-import-fastboot.js': { raw: 221142, gzip: 76707 },
+      'ember-website.js': { raw: -2995, gzip: -1013 },
+      'ember-website-fastboot.js': { raw: 0, gzip: 0 },
+      'vendor.js': { raw: -388401, gzip: -129560 },
+      'ember-website.css': { raw: 0, gzip: 0 },
+      'vendor.css': { raw: 0, gzip: 0 },
+    };
+    const totals = {
+      js: { raw: 3329042, gzip: 945089 },
+      css: { raw: 98184, gzip: 28143 },
+    };
+
+    const text = buildOutputText(diff, totals);
+
+    expect(text).to.equal(`Files that got Bigger 🚨:
+
+File | raw | gzip
+--- | --- | ---
+auto-import-fastboot.js|+221 kB|+76.7 kB
+
+Files that got Smaller 🎉:
+
+File | raw | gzip
+--- | --- | ---
+ember-website.js|-3 kB|-1.01 kB
+vendor.js|-388 kB|-130 kB
+
+
+Files that stayed the same size 🤷‍:
+
+File | raw | gzip
+--- | --- | ---
+ember-website-fastboot.js| 0 B| 0 B
+ember-website.css| 0 B| 0 B
+vendor.css| 0 B| 0 B
+
+
+Total Sizes 📊:
+
+File | raw | gzip
+--- | --- | ---
+js|+3.33 MB|+945 kB
+css|+98.2 kB|+28.1 kB`);
+  });
 });

--- a/test/diffTotals.js
+++ b/test/diffTotals.js
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import { diffTotals } from "../lib/helpers";
+
+describe("Diff Totals", function () {
+  it("should correctly report size differences between two branches (decreases, increases, and unchanged)", function () {
+    const masterTotals = {
+      css: {
+        raw: 2000,
+        gzip: 20,
+      },
+      js: {
+        raw: 2000,
+        gzip: 20,
+      },
+    };
+
+    const prTotals = {
+      css: {
+        raw: 2100,
+        gzip: 20,
+      },
+      js: {
+        raw: 1800,
+        gzip: 15,
+      },
+    };
+
+    const diff = diffTotals(prTotals, masterTotals);
+
+    expect(diff).to.deep.equal({
+      css: {
+        raw: 100,
+        gzip: 0,
+      },
+      js: {
+        raw: -200,
+        gzip: -5,
+      },
+    });
+  });
+});

--- a/test/diffTotals.js
+++ b/test/diffTotals.js
@@ -3,7 +3,7 @@ import { diffTotals } from "../lib/helpers";
 
 describe("Diff Totals", function () {
   it("should correctly report size differences between two branches (decreases, increases, and unchanged)", function () {
-    const masterTotals = {
+    const baseBranchTotals = {
       css: {
         raw: 2000,
         gzip: 20,
@@ -25,7 +25,7 @@ describe("Diff Totals", function () {
       },
     };
 
-    const diff = diffTotals(prTotals, masterTotals);
+    const diff = diffTotals(baseBranchTotals, prTotals);
 
     expect(diff).to.deep.equal({
       css: {

--- a/test/sumAssetSizes.js
+++ b/test/sumAssetSizes.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { sumAssetSizes } from '../lib/helpers.js';
+
+describe('sumAssetSizes', function () {
+  it('sums the total sizes for each file type', function() {
+    const assetSizeReport = {
+      'ember-website.js': { raw: 1000, gzip: 10, brotli: null },
+      'vendor.js': { raw: 1000, gzip: 10, brotli: null },
+      'ember-website.css': { raw: 1000, gzip: 10, brotli: null },
+      'vendor.css': { raw: 1000, gzip: 10, brotli: null },
+    };
+
+    const summedAssetSizes = sumAssetSizes(assetSizeReport);
+
+    expect(summedAssetSizes).to.deep.equal({
+      css: {
+        raw: 2000,
+        gzip: 20,
+      },
+      js: {
+        raw: 2000,
+        gzip: 20,
+      },
+    });
+  });
+});


### PR DESCRIPTION
This feature adds an argument called `show-total-size-diff`, which defaults to `no`. This can be set to `yes` to calculate the total asset size differences between the base branch vs the PR branch.

This is PR builds upon the excellent work done by @timiyay in https://github.com/simplabs/ember-asset-size-action/pull/27 but that PR reports just the total size of the artefacts, whereas this reports the total size diff after the changes in the PR. 

Given this repo doesn't seem to be merging PRs at the moment this is mainly being raised to help others who are after a total size diff feature. Since we bumped our application to `ember-auto-import@2` the `ember-asset-size-action` has stopped being able to map chunks to each other as the naming conventions don't allow for comparison anymore.