### PR TITLE
Account for deleted files when diffing assets

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -23471,7 +23471,8 @@ function normaliseFingerprint(obj) {
 function diffSizes(baseBranch, pullRequestBranch) {
   const diffObject = {};
 
-  Object.keys(pullRequestBranch).forEach((key) => {
+  const fileSizes = { ...baseBranch, ...pullRequestBranch };
+  Object.keys(fileSizes).forEach((key) => {
     const newSize = pullRequestBranch[key];
     const originSize = baseBranch[key];
 
@@ -23481,14 +23482,19 @@ function diffSizes(baseBranch, pullRequestBranch) {
         raw: newSize.raw,
         gzip: newSize.gzip,
       };
+    // deleted file i.e. does not exist in new branch
+    } else if (!newSize) {
+      diffObject[key] = {
+        raw: 0 - originSize.raw,
+        gzip: 0 - originSize.gzip,
+        deleted: true
+      };
     } else {
       diffObject[key] = {
         raw: newSize.raw - originSize.raw,
         gzip: newSize.gzip - originSize.gzip,
       };
     }
-
-    // TODO cater for deleted files
   });
 
   return diffObject;
@@ -23585,16 +23591,20 @@ function buildOutputText(output, showTotals) {
     file: key,
     raw: output[key].raw,
     gzip: output[key].gzip,
+    deleted: output[key].deleted
   }));
 
   const bigger = [];
   const smaller = [];
   const same = [];
+  const deleted = [];
 
   files.forEach((file) => {
     // the minimum change should be 10 bytes (bigger or smaller) before it is reported
     // this helps to avoid the slight jitter you sometimes find in the file sizes
-    if (file.raw > 10) {
+    if (file.deleted) {
+      deleted.push(file);
+    } else if (file.raw > 10) {
       bigger.push(file);
     } else if (file.raw < -10) {
       smaller.push(file);
@@ -23604,7 +23614,7 @@ function buildOutputText(output, showTotals) {
   });
 
   let outputText = '';
-  const totalFiles = bigger.length + smaller.length + same.length;
+  const totalFiles = bigger.length + smaller.length + deleted.length + same.length;
 
   if (bigger.length) {
     outputText += `${bigger.length}/${totalFiles} Files got Bigger 🚨:\n\n${reportTable(bigger)}\n`;
@@ -23612,6 +23622,10 @@ function buildOutputText(output, showTotals) {
 
   if (smaller.length) {
     outputText += `${smaller.length}/${totalFiles} Files got Smaller 🎉:\n\n${reportTable(smaller)}\n`;
+  }
+
+  if (deleted.length) {
+    outputText += `${deleted.length}/${totalFiles} Files got Deleted 🗑️:\n\n${reportTable(deleted)}\n`;
   }
 
   if (same.length) {

--- a/lib/helpers.mjs
+++ b/lib/helpers.mjs
@@ -27,7 +27,8 @@ export function normaliseFingerprint(obj) {
 export function diffSizes(baseBranch, pullRequestBranch) {
   const diffObject = {};
 
-  Object.keys(pullRequestBranch).forEach((key) => {
+  const fileSizes = { ...baseBranch, ...pullRequestBranch };
+  Object.keys(fileSizes).forEach((key) => {
     const newSize = pullRequestBranch[key];
     const originSize = baseBranch[key];
 
@@ -37,14 +38,18 @@ export function diffSizes(baseBranch, pullRequestBranch) {
         raw: newSize.raw,
         gzip: newSize.gzip,
       };
+    // deleted file i.e. does not exist in new branch
+    } else if (!newSize) {
+      diffObject[key] = {
+        raw: 0 - originSize.raw,
+        gzip: 0 - originSize.gzip,
+      };
     } else {
       diffObject[key] = {
         raw: newSize.raw - originSize.raw,
         gzip: newSize.gzip - originSize.gzip,
       };
     }
-
-    // TODO cater for deleted files
   });
 
   return diffObject;

--- a/lib/helpers.mjs
+++ b/lib/helpers.mjs
@@ -43,6 +43,7 @@ export function diffSizes(baseBranch, pullRequestBranch) {
       diffObject[key] = {
         raw: 0 - originSize.raw,
         gzip: 0 - originSize.gzip,
+        deleted: true
       };
     } else {
       diffObject[key] = {
@@ -146,16 +147,20 @@ export function buildOutputText(output, showTotals) {
     file: key,
     raw: output[key].raw,
     gzip: output[key].gzip,
+    deleted: output[key].deleted
   }));
 
   const bigger = [];
   const smaller = [];
   const same = [];
+  const deleted = [];
 
   files.forEach((file) => {
     // the minimum change should be 10 bytes (bigger or smaller) before it is reported
     // this helps to avoid the slight jitter you sometimes find in the file sizes
-    if (file.raw > 10) {
+    if (file.deleted) {
+      deleted.push(file);
+    } else if (file.raw > 10) {
       bigger.push(file);
     } else if (file.raw < -10) {
       smaller.push(file);
@@ -165,7 +170,7 @@ export function buildOutputText(output, showTotals) {
   });
 
   let outputText = '';
-  const totalFiles = bigger.length + smaller.length + same.length;
+  const totalFiles = bigger.length + smaller.length + deleted.length + same.length;
 
   if (bigger.length) {
     outputText += `${bigger.length}/${totalFiles} Files got Bigger 🚨:\n\n${reportTable(bigger)}\n`;
@@ -173,6 +178,10 @@ export function buildOutputText(output, showTotals) {
 
   if (smaller.length) {
     outputText += `${smaller.length}/${totalFiles} Files got Smaller 🎉:\n\n${reportTable(smaller)}\n`;
+  }
+
+  if (deleted.length) {
+    outputText += `${deleted.length}/${totalFiles} Files got Deleted 🗑️:\n\n${reportTable(deleted)}\n`;
   }
 
   if (same.length) {

--- a/test/buildOutputText.mjs
+++ b/test/buildOutputText.mjs
@@ -8,6 +8,7 @@ describe('Build output Text', function () {
       'ember-website.js': { raw: -2995, gzip: -1013 },
       'ember-website-fastboot.js': { raw: 0, gzip: 0 },
       'vendor.js': { raw: -388401, gzip: -129560 },
+      'deleted.js': { raw: -2388, gzip: -953, deleted: true },
       'ember-website.css': { raw: 0, gzip: 0 },
       'vendor.css': { raw: 0, gzip: 0 },
       'slightly-bigger.css': { raw: 7, gzip: 0 },
@@ -16,7 +17,7 @@ describe('Build output Text', function () {
 
     const text = buildOutputText(diff);
 
-    expect(text).to.equal(`1/8 Files got Bigger 🚨:
+    expect(text).to.equal(`1/9 Files got Bigger 🚨:
 
 <details>
   <summary>Details</summary>
@@ -27,7 +28,7 @@ auto-import-fastboot.js|+221 kB|+76.7 kB
 
 </details>
 
-2/8 Files got Smaller 🎉:
+2/9 Files got Smaller 🎉:
 
 <details>
   <summary>Details</summary>
@@ -39,7 +40,18 @@ vendor.js|-388 kB|-130 kB
 
 </details>
 
-5/8 Files stayed the same size 🤷‍:
+1/9 Files got Deleted 🗑️:
+
+<details>
+  <summary>Details</summary>
+
+File | raw | gzip
+--- | --- | ---
+deleted.js|-2.39 kB|-953 B
+
+</details>
+
+5/9 Files stayed the same size 🤷‍:
 
 <details>
   <summary>Details</summary>
@@ -60,6 +72,7 @@ slightly-smaller.css|-3 B| 0 B
       'auto-import-fastboot.js': { raw: 221142, gzip: 76707 },
       'ember-website.js': { raw: -2995, gzip: -1013 },
       'ember-website-fastboot.js': { raw: 0, gzip: 0 },
+      'deleted.js': { raw: -2388, gzip: -953, deleted: true },
       'vendor.js': { raw: -388401, gzip: -129560 },
       'ember-website.css': { raw: 0, gzip: 0 },
       'vendor.css': { raw: 0, gzip: 0 },
@@ -67,7 +80,7 @@ slightly-smaller.css|-3 B| 0 B
 
     const text = buildOutputText(diff, true);
 
-    expect(text).to.equal(`1/6 Files got Bigger 🚨:
+    expect(text).to.equal(`1/7 Files got Bigger 🚨:
 
 <details>
   <summary>Details</summary>
@@ -78,7 +91,7 @@ auto-import-fastboot.js|+221 kB|+76.7 kB
 
 </details>
 
-2/6 Files got Smaller 🎉:
+2/7 Files got Smaller 🎉:
 
 <details>
   <summary>Details</summary>
@@ -90,7 +103,18 @@ vendor.js|-388 kB|-130 kB
 
 </details>
 
-3/6 Files stayed the same size 🤷‍:
+1/7 Files got Deleted 🗑️:
+
+<details>
+  <summary>Details</summary>
+
+File | raw | gzip
+--- | --- | ---
+deleted.js|-2.39 kB|-953 B
+
+</details>
+
+3/7 Files stayed the same size 🤷‍:
 
 <details>
   <summary>Details</summary>
@@ -107,7 +131,7 @@ Total assets size diff📊:
 
 File | raw | gzip
 --- | --- | ---
-js|-170 kB|-53.9 kB
+js|-173 kB|-54.8 kB
 css| 0 B| 0 B`);
   });
 });

--- a/test/diffSizes.mjs
+++ b/test/diffSizes.mjs
@@ -30,7 +30,7 @@ describe('Diff Sizes', function () {
       'vendor.js': { raw: 388401, gzip: 129560 },
       'ember-website.css': { raw: 0, gzip: 0 },
       'vendor.css': { raw: 0, gzip: 0 },
-      'extra.js': { raw: -2388, gzip: -953 },
+      'extra.js': { raw: -2388, gzip: -953, deleted: true },
     });
   });
 });

--- a/test/diffSizes.mjs
+++ b/test/diffSizes.mjs
@@ -18,6 +18,7 @@ describe('Diff Sizes', function () {
       'vendor.js': { raw: 2329192, gzip: 666522, brotli: null },
       'ember-website.css': { raw: 40196, gzip: 10223, brotli: null },
       'vendor.css': { raw: 57988, gzip: 17920, brotli: null },
+      'extra.js': { raw: 2388, gzip: 953, brotli: null },
     };
 
     const diff = diffSizes(masterAssets, prAssets);
@@ -29,6 +30,7 @@ describe('Diff Sizes', function () {
       'vendor.js': { raw: 388401, gzip: 129560 },
       'ember-website.css': { raw: 0, gzip: 0 },
       'vendor.css': { raw: 0, gzip: 0 },
+      'extra.js': { raw: -2388, gzip: -953 },
     });
   });
 });


### PR DESCRIPTION
Currently, deleted files (files that exist on the trunk branch but no longer exist in the PR branch) are ignored in the final asset size diff. This PR changes the asset diffing helper so that deleted files _are_ included.