### PR TITLE
Wrap the file tables in a <details>

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -162,12 +162,17 @@ async function getAssetSizes() {
 }
 
 function reportTable(data) {
-  let table = `File | raw | gzip
+  let table = `<details>
+  <summary>Details</summary>
+
+File | raw | gzip
 --- | --- | ---
 `;
   data.forEach((item) => {
     table += `${item.file}|${pretty_bytes_default()(item.raw, { signed: true })}|${pretty_bytes_default()(item.gzip, { signed: true })}\n`;
   });
+
+  table += '\n</details>\n';
 
   return table;
 }
@@ -194,17 +199,18 @@ function buildOutputText(output) {
   });
 
   let outputText = '';
+  const totalFiles = bigger.length + smaller.length + same.length;
 
   if (bigger.length) {
-    outputText += `Files that got Bigger 🚨:\n\n${reportTable(bigger)}\n`;
+    outputText += `${bigger.length}/${totalFiles} Files got Bigger 🚨:\n\n${reportTable(bigger)}\n`;
   }
 
   if (smaller.length) {
-    outputText += `Files that got Smaller 🎉:\n\n${reportTable(smaller)}\n\n`;
+    outputText += `${smaller.length}/${totalFiles} Files got Smaller 🎉:\n\n${reportTable(smaller)}\n`;
   }
 
   if (same.length) {
-    outputText += `Files that stayed the same size 🤷‍:\n\n${reportTable(same)}\n\n`;
+    outputText += `${same.length}/${totalFiles} Files stayed the same size 🤷‍:\n\n${reportTable(same)}\n`;
   }
 
   return outputText.trim();

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -116,12 +116,17 @@ export async function getAssetSizes() {
 }
 
 function reportTable(data) {
-  let table = `File | raw | gzip
+  let table = `<details>
+  <summary>Details</summary>
+
+File | raw | gzip
 --- | --- | ---
 `;
   data.forEach((item) => {
     table += `${item.file}|${prettyBytes(item.raw, { signed: true })}|${prettyBytes(item.gzip, { signed: true })}\n`;
   });
+
+  table += '\n</details>\n';
 
   return table;
 }
@@ -148,17 +153,18 @@ export function buildOutputText(output) {
   });
 
   let outputText = '';
+  const totalFiles = bigger.length + smaller.length + same.length;
 
   if (bigger.length) {
-    outputText += `Files that got Bigger 🚨:\n\n${reportTable(bigger)}\n`;
+    outputText += `${bigger.length}/${totalFiles} Files got Bigger 🚨:\n\n${reportTable(bigger)}\n`;
   }
 
   if (smaller.length) {
-    outputText += `Files that got Smaller 🎉:\n\n${reportTable(smaller)}\n\n`;
+    outputText += `${smaller.length}/${totalFiles} Files got Smaller 🎉:\n\n${reportTable(smaller)}\n`;
   }
 
   if (same.length) {
-    outputText += `Files that stayed the same size 🤷‍:\n\n${reportTable(same)}\n\n`;
+    outputText += `${same.length}/${totalFiles} Files stayed the same size 🤷‍:\n\n${reportTable(same)}\n`;
   }
 
   return outputText.trim();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Show asset size changes on ",
   "main": "index.js",
   "scripts": {
-    "test": "npm run build && cross-env NODE_ENV=TEST GITHUB_REPOSITORY=simplabs/ember-asset-size-action mocha -r esm",
+    "test": "cross-env NODE_ENV=TEST GITHUB_REPOSITORY=simplabs/ember-asset-size-action mocha -r esm",
     "lint": "eslint .",
     "build": "ncc build index.js"
   },

--- a/test/buildOutputText.js
+++ b/test/buildOutputText.js
@@ -14,26 +14,40 @@ describe('Build output Text', function () {
 
     const text = buildOutputText(diff);
 
-    expect(text).to.equal(`Files that got Bigger 🚨:
+    expect(text).to.equal(`1/6 Files got Bigger 🚨:
+
+<details>
+  <summary>Details</summary>
 
 File | raw | gzip
 --- | --- | ---
 auto-import-fastboot.js|+221 kB|+76.7 kB
 
-Files that got Smaller 🎉:
+</details>
+
+2/6 Files got Smaller 🎉:
+
+<details>
+  <summary>Details</summary>
 
 File | raw | gzip
 --- | --- | ---
 ember-website.js|-3 kB|-1.01 kB
 vendor.js|-388 kB|-130 kB
 
+</details>
 
-Files that stayed the same size 🤷‍:
+3/6 Files stayed the same size 🤷‍:
+
+<details>
+  <summary>Details</summary>
 
 File | raw | gzip
 --- | --- | ---
 ember-website-fastboot.js| 0 B| 0 B
 ember-website.css| 0 B| 0 B
-vendor.css| 0 B| 0 B`);
+vendor.css| 0 B| 0 B
+
+</details>`);
   });
 });


### PR DESCRIPTION
Since #33 was merged (in #47) we have the possibility of **VERY**  large tables in the asset-size comment 🙈 

This PR is attempting to mitigate that by wrapping the table in a `<details>` so it won't be opened by default