### PR TITLE
add support to specify a working-directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Update existing asset size comment instead of creating a new one each time'
     required: false
     default: 'yes'
+  working-directory:
+    description: 'The directory to run ember build from (and where the dist folder will be)'
+    required: false
+    default: ''
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/lib/helpers.mjs
+++ b/lib/helpers.mjs
@@ -101,10 +101,10 @@ export async function installDependencies() {
   return exec('npm install');
 }
 
-export async function getAssetSizes() {
+export async function getAssetSizes({ cwd }) {
   await installDependencies();
 
-  await exec('npx ember build -prod');
+  await exec('npx ember build -prod', { cwd });
 
   let prAssets;
 
@@ -116,7 +116,7 @@ export async function getAssetSizes() {
         prAssets = JSON.parse(text);
       },
     },
-    cwd: process.cwd(),
+    cwd,
   });
 
   return prAssets;

--- a/lib/helpers.mjs
+++ b/lib/helpers.mjs
@@ -75,13 +75,13 @@ export async function getPullRequest(context, octokit) {
 
 export async function installDependencies() {
   if (fs.existsSync('yarn.lock')) {
-    return exec('yarn --frozen-lockfile');
+    return exec('yarn', ['--frozen-lockfile']);
   }
 
   if (fs.existsSync('package-lock.json')) {
     const packageLock = JSON.parse(fs.readFileSync('package-lock.json'));
     let npmVersion = '';
-    await exec('npm -v', {
+    await exec('npm', ['-v'], {
       stdout: (data) => {
         npmVersion += data.toString();
       },
@@ -91,20 +91,20 @@ export async function installDependencies() {
       packageLock.lockfileVersion === 2
       && semver.lt(npmVersion, '7.0.0')
     ) {
-      return exec('npx npm@7 ci');
+      return exec('npx', ['npm@7', 'ci']);
     }
 
-    return exec('npm ci');
+    return exec('npm', ['ci']);
   }
 
   console.warn('No package-lock.json or yarn.lock detected! We strongly recommend committing one');
-  return exec('npm install');
+  return exec('npm', ['install']);
 }
 
 export async function getAssetSizes({ cwd }) {
   await installDependencies();
 
-  await exec('npx ember build -prod', { cwd });
+  await exec('npx', ['ember', 'build', '-prod'], { cwd });
 
   let prAssets;
 

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 import { getInput, setFailed } from '@actions/core';
 import { exec } from '@actions/exec';
 import { getOctokit, context } from '@actions/github';
+import path from 'path';
 
 import {
   normaliseFingerprint,
@@ -19,11 +20,15 @@ async function run() {
     const pullRequest = await getPullRequest(context, octokit);
 
     const showTotalSizeDiff = getInput('show-total-size-diff', { required: false }) === 'yes';
-    const prAssets = await getAssetSizes();
+
+    const workingDirectory = getInput('working-directory', { required: false });
+    const cwd = path.join(process.cwd(), workingDirectory);
+
+    const prAssets = await getAssetSizes({ cwd });
 
     await exec(`git checkout ${pullRequest.base.sha}`);
 
-    const masterAssets = await getAssetSizes();
+    const masterAssets = await getAssetSizes({ cwd });
 
     const fileDiffs = diffSizes(normaliseFingerprint(masterAssets), normaliseFingerprint(prAssets));
 


### PR DESCRIPTION
this PR also fixes the use of the `exec()` function from `@actions/exec`. We never noticed we were using it wrong because we weren't passing any options before, and we couldn't pass `cwd` effectively while it was being used wrong 