### PR TITLE
Fix @github/exec invocation for npm version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -23532,8 +23532,10 @@ async function installDependencies() {
     const packageLock = JSON.parse(external_fs_.readFileSync('package-lock.json'));
     let npmVersion = '';
     await (0,exec.exec)('npm', ['-v'], {
-      stdout: (data) => {
-        npmVersion += data.toString();
+      listeners: {
+        stdout: (data) => {
+          npmVersion += data.toString();
+        },
       },
     });
 

--- a/lib/helpers.mjs
+++ b/lib/helpers.mjs
@@ -86,8 +86,10 @@ export async function installDependencies() {
     const packageLock = JSON.parse(fs.readFileSync('package-lock.json'));
     let npmVersion = '';
     await exec('npm', ['-v'], {
-      stdout: (data) => {
-        npmVersion += data.toString();
+      listeners: {
+        stdout: (data) => {
+          npmVersion += data.toString();
+        },
       },
     });
 


### PR DESCRIPTION
Fix `@github/exec` invocation.
https://github.com/actions/toolkit/tree/main/packages/exec#outputoptions

Fixes #71.